### PR TITLE
fix: async signature info

### DIFF
--- a/cli/realease.js
+++ b/cli/realease.js
@@ -159,10 +159,15 @@ async function main() {
       "checking out release branch"
     );
 
+    // Get signature config
+    let sign = await tryAsync(
+      () => Git.Signature.default(repo),
+      "getting signature info for repository"
+    )
+
     // Create commit on release branch
     let commitMessage = message.replace("{version}", newVersion);
     console.log(`Creating release commit with message ${commitMessage}`);
-    let sign = Git.Signature.default(repo);
     await tryAsync(
       () =>
         repo.createCommitOnHead(


### PR DESCRIPTION
`Git.Signature.default` is async (see [docs](https://www.nodegit.org/api/signature/#default)), and passing a promise to `repo.createCommitOnHead` fails with a segfault in recent nodegit versions.